### PR TITLE
Improvements on ratio computation for preserved text

### DIFF
--- a/maya/nltk/util.py
+++ b/maya/nltk/util.py
@@ -174,11 +174,20 @@ def getInsertedContentSinceParentRevision(parent_rev, new_rev):
     return content
 
 def textPreservedRatio(o_text, d_text):
-    ratio = 0
-    seq = []
-    for text in o_text:
-        seq = difflib.SequenceMatcher(None, text, d_text, autojunk=False).get_matching_blocks()
-        total_matched = sum(int(v[2]) for v in seq)
-        ratio += total_matched/len(text)
+    """
+   Compute the ratio of preserved text between two revisions
 
-    return ratio/len(o_text)
+   Args:
+       o_text (list): a list of elements of the form [index of insertion position, text to be inserted]
+       d_text (str): text content of the destination revision.
+
+   Result:
+       ratio of preserved text (real).
+    """
+    total = 0
+    total_matched = 0
+    for text in o_text:
+        matches = difflib.SequenceMatcher(None, text, d_text, autojunk=False).get_matching_blocks()
+        total_matched += sum(int(match[2]) for match in matches)
+        total += len(text)
+    return total_matched / total

--- a/maya/nltk/util.py
+++ b/maya/nltk/util.py
@@ -157,6 +157,22 @@ def findDiffRevised(parent_rev, current_rev):
     return insert_ops
 
 
+def getInsertedContentSinceParentRevision(parent_rev, new_rev):
+    """
+   Compute text content that was inserted in a revision since another revision (string).
+   The computed differences are computed, only insertions are kept. Then their text content is merged into a string.
+
+   Args:
+       parent_rev (str): text content of a revision.
+       new_rev (str): text content of a newer revision.
+
+   Result:
+       the inserted text content (str)
+    """
+    ops = util.findDiffRevised(parent_rev, new_rev)
+    content = "".join([ o[1] for o in ops ])
+    return content
+
 def textPreservedRatio(o_text, d_text):
     ratio = 0
     seq = []


### PR DESCRIPTION
Please note that computation should be performed as follows:
```python
insert_ops = util.findDiffRevised(parent_rev, contributed_rev)
o_text = list(op[1] for op in insert_ops)

d_text = getInsertedContentSinceParentRevision(parent_rev, next_rev):

ratio = textPreservedRatio(o_text, d_text)
```